### PR TITLE
Adds and example of composable nodes with yaml file config

### DIFF
--- a/config/image_tools_parameters.yaml
+++ b/config/image_tools_parameters.yaml
@@ -12,7 +12,8 @@
 
 # This yaml format does not works when configuring the parameters in a
 # launch file. This is a bug that is solved in Galactic and onwards and
-# have not being backported to Foxy. The workaround is to use the following format:
+# have not being backported to Foxy (https://github.com/ros2/launch_ros/pull/259).
+# The workaround is to use the following format:
 
 burger_mode: True 
 height: 300

--- a/config/image_tools_parameters.yaml
+++ b/config/image_tools_parameters.yaml
@@ -1,0 +1,21 @@
+# The usual format of the yaml file would be something like this:
+#cam2image:
+#  ros__parameters:
+#    burger_mode: True 
+#    height: 300
+#    width: 200
+
+#showimage:
+#  ros__parameters:
+#    depth: 1
+#    history: keep_last
+
+# This yaml format does not works when configuring the parameters in a
+# launch file. This is a bug that is solved in Galactic and onwards and
+# have not being backported to Foxy. The workaround is to use the following format:
+
+burger_mode: True 
+height: 300
+width: 200
+depth: 1
+history: keep_last

--- a/config/image_tools_parameters.yaml
+++ b/config/image_tools_parameters.yaml
@@ -1,14 +1,14 @@
 # The usual format of the yaml file would be something like this:
-#cam2image:
-#  ros__parameters:
-#    burger_mode: True 
-#    height: 300
-#    width: 200
+# cam2image:
+#   ros__parameters:
+#     burger_mode: True 
+#     height: 300
+#     width: 200
 
-#showimage:
-#  ros__parameters:
-#    depth: 1
-#    history: keep_last
+# showimage:
+#   ros__parameters:
+#     depth: 1
+#     history: keep_last
 
 # This yaml format does not works when configuring the parameters in a
 # launch file. This is a bug that is solved in Galactic and onwards and

--- a/launch/README.md
+++ b/launch/README.md
@@ -92,3 +92,5 @@ Run ros2 launch.
 ```sh
 ros2 launch ros2_launch_examples composable_node_yaml.launch.py
 ```
+
+### Note: Check all the launch files for the code explanation. 

--- a/launch/README.md
+++ b/launch/README.md
@@ -84,3 +84,11 @@ Run ros2 launch.
 ```sh
 ros2 launch ros2_launch_examples parent_child.launch.py
 ```
+
+## composable_node_yaml.launch.py
+Launch file with composable nodes with parameters configured via a YAML file.
+### Try it out
+Run ros2 launch.
+```sh
+ros2 launch ros2_launch_examples composable_node_yaml.launch.py
+```

--- a/launch/composable_node_yaml.launch.py
+++ b/launch/composable_node_yaml.launch.py
@@ -1,0 +1,45 @@
+import os
+import launch
+import launch.actions
+
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+
+    # This variable obtains the path of the yaml file that have the parameter configuration.
+    # In order for this to work, the yaml file must be installed into the share folder of 
+    # the package, check the setup.py file lines 18-19.
+    config = os.path.join(
+        get_package_share_directory('ros2_launch_examples'),
+        'config',
+        'image_tools_parameters.yaml'
+        )
+
+    # On this variable we create a Component Container where the components will be loaded.
+    container = ComposableNodeContainer(
+        name='image_tools_container',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
+        composable_node_descriptions=[
+            #The composable nodes we load to the container have parameters that can be configured
+            # in 2 possible ways: 
+            #   - Create a dictionary with the parameters names and values. Ex: parameters=[burger_mode: True, height: 200, width: 300]
+            #   - Give the path to the yaml file configuration (on this case, the variable we defined before as `config`). Ex:
+            ComposableNode(
+                package='image_tools',
+                plugin='image_tools::Cam2Image',
+                name='cam_2_image',
+                parameters=[config]),
+            ComposableNode(
+                package='image_tools',
+                plugin='image_tools::ShowImage',
+                name='show_image',
+                parameters=[config]),
+        ],
+        output='screen',
+    )
+
+    return launch.LaunchDescription([container])

--- a/launch/composable_node_yaml.launch.py
+++ b/launch/composable_node_yaml.launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
 
     # This variable obtains the path of the yaml file that have the parameter configuration.
     # In order for this to work, the yaml file must be installed into the share folder of 
-    # the package, check the setup.py file lines 18-19.
+    # the package, check the setup.py file on the data files section.
     config = os.path.join(
         get_package_share_directory('ros2_launch_examples'),
         'config',

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,8 @@
   <maintainer email="franco.c@ekumenlabs.com">Franco Cipollone</maintainer>
   <license>LICENSE</license>
 
+
+  <exec_depend>image_tools</exec_depend>
   <exec_depend>turtlesim</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/launch',
             glob.glob(os.path.join('launch', '*.launch.py'))),
+        ('share/' + package_name + '/config',
+            glob.glob(os.path.join('config','*.yaml'))),
     ],
     install_requires=[
         'launch',


### PR DESCRIPTION
This PR gives an example of a launch file for Composables Nodes which parameters are configured via a YAML file.